### PR TITLE
为 SimpleRSS 适配 Manifest V2

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -47,7 +47,7 @@ LegacyItem65,Unlock mi Phone,quick_app,Azumachiaki,ulmp,0a1d79d,icon.png,cover.p
 LegacyItem66,绘刻系列,watchface,Ziyimiao5054,Drawing-Carve,9f0f338,icon.png,cover.png,表盘;二次元;免费;景深,xiaomi,xmb10;xmb10nfc,
 LegacyItem67,Material You,watchface,YangWan233,Material-You_AstroBox,4461c90,icon.png,cover.png,表盘;免费;简约,xiaomi,xmb9p,
 LegacyItem69,粗粮备跑网,quick_app,OrPudding,MiRun-BandTwine,2ad110f,icon.png,cover.png,游戏;免费;自愿捐赠;AstroBox专属;梗;玩机,xiaomi,xmb9;xmb10;xmws3;xmws4;xmws4xring;xmb10nfc;xmb9p,
-LegacyItem71,SimpleRSS 简读,quick_app,yzl3014,AstroBox_SimpleRSS,b18f8e0,logo.png,cover.png,工具;阅读;RSS,xiaomi,xmb9p,
+com.yzl3014.simplerss,SimpleRSS 简读,quick_app,yzl3014,AstroBox_SimpleRSS,0c031b0,logo.png,cover.png,工具;阅读;RSS,xiaomi,xmb9p;xmrw5;xmrw5xring,
 LegacyItem72,MIPhone Go,quick_app,wanggantian,MIPhonego,88e0df7,icon.png,cover.png,游戏;免费;梗,xiaomi,xmb9p,
 LegacyItem73,环间古诗词,quick_app,DDguan2010,vela-poem,fd0e396,icon.png,preview0.png,工具;古诗词;学习,xiaomi,xmb10;xmb10nfc;xmb9;xmb9p,force_paid
 LegacyItem74,雪山动态_S4,watchface,Ziyimiao5054,Snow-Mountain_S4,72f515c,icon.png,cover.png,表盘;动态;雪山,xiaomi,xmws4;xmws4xring,


### PR DESCRIPTION
已添加 `manifest_v2.json`
Commit `0c031b0` 在`links`添加了应用介绍视频
应用的最后版本有对红米手表5的屏幕适配，可能还不够好。我手头没有该设备

我没有 AstroBox 2.0 的内测资格，如有问题请回复给我，非常感谢。

初代：https://github.com/yzl3014/AstroBox_SimpleRSS/blob/main/manifest.json
V2：https://github.com/yzl3014/AstroBox_SimpleRSS/blob/main/manifest_v2.json