### PR TITLE
add: 腕上词典 + 化学工具箱 - AstroBox v2 submission

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -165,3 +165,5 @@ com.kevin.en,腕上单词,quick_app,AzumaChiaki,BandEnglish_ab,fa8856a,media/log
 com.azuma.syclass,Var课程表,quick_app,AzumaChiaki,VarClass-ab,c92f6e5,media/icon.png,media/cover.png,课程表;效率;工具,xiaomi,xmrw5;xmrw5xring;xmrw6;xmb10;xmb10nfc;xmb9;xmb10p;xmb9p;xmws3;xmws4xring;xmws441;xmws4;xmws5,force_paid
 com.remote.terminal,远程终端,quick_app,F7YM,astrobox-resource-com-remote-terminal,ab36f9f,media/RemoteTerminal.png,media/Group 7 (2).png,远程控制;Linux;Windows;SSH,xiaomi,xmrw5;xmrw5xring;xmrw6;xmb9p;xmws3;xmws4xring;xmws441;xmws4;xmws5,
 979811130359,天归 - 天容万象 星途终归,watchface,auberdominique23-hash,979811130359_AstroBox_Release,4875f37,矩形 1.png,MasterGo 封面 16_9 - 2.png,二次元表盘;课程表;lua表盘,xiaomi,xmb9p;xmb10p,force_paid
+com.watch.dic,腕上词典,quick_app,pcai7296,---,3b0de13,icon.png,cover.png,实用工具;词典;学习;离线;免费,xiaomi,xmb10;xmb10nfc,
+com.chemistry.toolbox.miband,化学工具箱,quick_app,pcai7296,---,4bba489,icon.png,cover.png,化学;工具;周期表;离线;免费,xiaomi,xmb10;xmb10nfc,


### PR DESCRIPTION
## 腕上词典

小米手环端离线英汉词典，抬手即查。
支持英语、汉字、变形查词，全程离线。

## 化学工具箱

小米手环端离线化学方程式查询与周期表工具。
支持 1500+ 条化学反应方程式、元素周期表、化学式专用键盘。

**设备支持：** xmb10 / xmb10nfc

**发布仓库：** pcai7296/--- (commit 3b0de13 / 4bba489)