### PR TITLE
[ABoooxCC] 发布 杭州麻将 快应用

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -172,3 +172,4 @@ com.watch.dic,腕上词典,quick_app,pcai7296,com.watch.dic_AstroBox_Release,f40
 979899954912,复古液晶显示,watchface,Cannyworks29,RetroSTNdisplay3,2afa51a,media/画板 1 副本3.png,media/_7146450 2.jpg,复古;液晶;像素;渐变;极简,xiaomi,xmb10p;xmb9p,
 me.cjack.b2048n,2048N,quick_app,CJackHwang,2048N_AstroBox_Release,d111493,src/common/logo.png,src/common/head15.png,免费;开源;2048;游戏;小米手环10;快应用,xiaomi,xmb10;xmb10nfc,
 979899954914,圆饼三指针,watchface,Cannyworks29,Three-Disk-Hands,f872685,media/画板 2523.png,media/封面图 横构图_4245899.jpg,极简;指针,xiaomi,xmb10p;xmb9p;xmrw5;xmrw5xring;xmrw6;xmb10;xmb10nfc;xmb9;xmws5,
+com.openblack.mahjong,杭州麻将,quick_app,dm1366631,mahjong-game_AstroBox_Release,87292d0,src/common/icon.png,cover/cover.jpg,麻将;游戏,xiaomi,xmb10nfc;xmb10;xmb10p;xmb9p,


### PR DESCRIPTION
## 资源信息

- 资源名称：杭州麻将
- 资源 ID：com.openblack.mahjong
- 资源类型：快应用（quick_app）
- 提交版本：v2
- 付费类型：免费
- AstroBoxCreator 加密功能：关闭
- 标签：麻将 / 游戏

## 支持设备

- Xiaomi Smart Band 10 NFC（device_id: xmb10nfc）
- Xiaomi Smart Band 10（device_id: xmb10）
- Xiaomi Smart Band 10 Pro（device_id: xmb10p）
- Xiaomi Smart Band 9 Pro（device_id: xmb9p）

## 仓库信息

- 资源仓库：https://github.com/dm1366631/mahjong-game_AstroBox_Release
- 提交短哈希：`87292d0`

## 图片资源（Raw）

- Icon：`src/common/icon.png`  
https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/src/common/icon.png
- Cover：`cover/cover.jpg`  
https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/cover/cover.jpg
- Preview：
- `cover/1.png`
  https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/cover/1.png
- `cover/2.png`
  https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/cover/2.png
- `cover/3.png`
  https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/cover/3.png
- `cover/4.png`
  https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/cover/4.png

## 下载资源（downloads）

- Xiaomi Smart Band 10 NFC（device_id: xmb10nfc）
  - version: `1.0.0`
  - file: `dist/com.openblack.mahjong.release.1.0.0.rpk`
  - raw: https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/dist/com.openblack.mahjong.release.1.0.0.rpk
- Xiaomi Smart Band 10（device_id: xmb10）
  - version: `1.0.0`
  - file: `dist/com.openblack.mahjong.release.1.0.0.rpk`
  - raw: https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/dist/com.openblack.mahjong.release.1.0.0.rpk
- Xiaomi Smart Band 10 Pro（device_id: xmb10p）
  - version: `1.0.0`
  - file: `dist/com.openblack.mahjong.release.1.0.0.rpk`
  - raw: https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/dist/com.openblack.mahjong.release.1.0.0.rpk
- Xiaomi Smart Band 9 Pro（device_id: xmb9p）
  - version: `1.0.0`
  - file: `dist/com.openblack.mahjong.release.1.0.0.rpk`
  - raw: https://raw.githubusercontent.com/dm1366631/mahjong-game_AstroBox_Release/refs/heads/main/dist/com.openblack.mahjong.release.1.0.0.rpk
## 链接（manifest_v2.links）

- mahjong-game（github-logo）：https://github.com/dm1366631/mahjong-game

---
此 PR 由 [AstroBooox Creator Console](https://astrobooox-ng.waijade.cn/) 生成，如有问题前往 [AstroBooox 仓库](https://github.com/CheongSzesuen/AstroBooox) 提交 [Issue](https://github.com/CheongSzesuen/AstroBooox/issues)。