### PR TITLE
添加留声光影表盘

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -187,4 +187,4 @@ com.shell.liangyi,Shell++,quick_app,IKUN-CXKPRO,astrobox-resource-com-shell-lian
 com.openblack.24point,24点,quick_app,dm1366631,astrobox-resource-com-openblack-24point,e811a0e,media/logo.png,media/cover.png,游戏;益智,xiaomi,xmb10;xmb10nfc;xmb10p,
 979824700000,24/7-相册表盘,watchface,AL-1S-hash,astrobox-resource-979824700000,597866c,media/Group 68.png,media/Frame 8.png,EVOA;孤星计划;极简;拟物;相册表盘;时钟;商务;多跳转,xiaomi,xmb10p;xmb9p,force_paid
 979860689210,「如初」-相册表盘,watchface,shantuskat,astrobox-resource-979860689210,8aae71b,media/画板 2.png,media/画板 18.png,相册;二次元;原神;明日方舟;蔚蓝档案;崩坏星穹铁道,xiaomi,xmb10;xmb10nfc;xmb9p;xmb10p;xmrw6,force_paid
-979801230101,留声光影,watchface,jianding24,vinyl-glow-dial-astrobox,485b37a,media/icon.png,media/cover.png,表盘;免费;黑胶;音乐;双主题;AOD,xiaomi,xmb9p,
+979801230101,留声光影,watchface,jianding24,vinyl-glow-dial-astrobox,c58804e,media/icon.png,media/cover.png,表盘;免费;黑胶;音乐;双主题;AOD,xiaomi,xmb9p,

--- a/index_v2.csv
+++ b/index_v2.csv
@@ -187,3 +187,4 @@ com.shell.liangyi,Shell++,quick_app,IKUN-CXKPRO,astrobox-resource-com-shell-lian
 com.openblack.24point,24点,quick_app,dm1366631,astrobox-resource-com-openblack-24point,e811a0e,media/logo.png,media/cover.png,游戏;益智,xiaomi,xmb10;xmb10nfc;xmb10p,
 979824700000,24/7-相册表盘,watchface,AL-1S-hash,astrobox-resource-979824700000,597866c,media/Group 68.png,media/Frame 8.png,EVOA;孤星计划;极简;拟物;相册表盘;时钟;商务;多跳转,xiaomi,xmb10p;xmb9p,force_paid
 979860689210,「如初」-相册表盘,watchface,shantuskat,astrobox-resource-979860689210,8aae71b,media/画板 2.png,media/画板 18.png,相册;二次元;原神;明日方舟;蔚蓝档案;崩坏星穹铁道,xiaomi,xmb10;xmb10nfc;xmb9p;xmb10p;xmrw6,force_paid
+979801230101,留声光影,watchface,jianding24,vinyl-glow-dial-astrobox,485b37a,media/icon.png,media/cover.png,表盘;免费;黑胶;音乐;双主题;AOD,xiaomi,xmb9p,


### PR DESCRIPTION
## 资源信息
- 名称：留声光影
- 类型：watchface
- 设备：xmb9p
- 价格：免费
- 发布仓库：https://github.com/jianding24/vinyl-glow-dial-astrobox
- 发布提交：485b37a

## 检查
- manifest_v2.json 位于发布仓库根目录
- manifest 名称与 index_v2.csv 名称一致
- icon、cover、preview、downloads 文件均在发布仓库中存在
- cover 为 1200x800
- icon 为 192x192