### PR TITLE
[ABoooxCC] 更新 真智学 快应用

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -176,7 +176,7 @@ asia.bilibili.mfa,【腕码】BandOTP,quick_app,lin945,BandOTP_Release,d8631821,
 com.watch.dic,腕上词典,quick_app,pcai7296,com.watch.dic_AstroBox_Release,19d2bb8,icon.png,cover.png,离线;英语;学习;词典;免费,xiaomi,xmb10;xmb10nfc;xmb9;xmb9p;xmws4;xmrw5;xmrw5xring;xmrw6;xmb10p,
 979809640178,「时语」-相册表盘,watchface,shantuskat,astrobox-resource-979809640178,95c6517,media/Image_1784250240657_832.png,media/画板 18(1).png,相册;二次元;可编辑;表盘,xiaomi,xmb10p;xmb9p;xmb10;xmrw6;xmb10nfc,force_paid
 979820260630,「Layer UI」- 相册表盘,watchface,ChiHuan0807,astrobox-resource-979820260630,6036957,media/LOGO.png,media/22922.png,池焕;迟缓;相册;表盘;简约;模糊;拍立得;相片,xiaomi,xmb10p;xmb9p;xmrw5;xmrw5xring;xmrw6,force_paid
-cn.seedsoft.realzhixue,真智学,quick_app,virelyx258,cn.seedsoft.realzhixue_AstroBox_Release,06bd235,logo-hd.png,cover.png,学习;校园;工具,xiaomi,xmb9p;xmrw5xring;xmrw5;xmrw6;xmws441;xmws4;xmws4xring;xmws3,
+cn.seedsoft.realzhixue,真智学,quick_app,virelyx258,cn.seedsoft.realzhixue_AstroBox_Release,768fb4d,logo-hd.png,cover.png,学习;校园;工具,xiaomi,xmb9p;xmrw5xring;xmrw5;xmrw6;xmws441;xmws4;xmws4xring;xmws3,
 com.openblack.mahjong,杭州麻将,quick_app,dm1366631,astrobox-resource-com-openblack-mahjong,16800c6,media/icon.png,media/cover.png,游戏,xiaomi,xmb10nfc;xmb10;xmb10p,
 com.SoDictionary.solan,So词典[英-日-汉互译版],quick_app,Solan-486,Astrobox-Resource_Release,6730971,icon.png,Preview1.3.png,词典;英语;英汉互译;日语;日文;日汉互译;英语词典;日语词典;学习;工具;翻译,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmrw5;xmrw5xring;xmrw6;xmb10p;xmws3;xmws4;xmws4xring;xmws441;xmws5,force_paid
 979818864961,一个小时的进度,watchface,Cannyworks29,One-Hour-Progress,83ae6cd,media/画板 1.png,media/_7206511_副本.jpg,极简;抽象;进度;数字,xiaomi,xmb10p;xmb9p,force_paid


### PR DESCRIPTION
## 资源信息

- 资源名称：真智学
- 资源 ID：cn.seedsoft.realzhixue
- 资源类型：快应用（quick_app）
- 付费类型：免费
- 标签：学习 / 校园 / 工具

## 本次变更

- 未检测到字段变化（仅同步仓库文件）

## 仓库信息

- 资源仓库：https://github.com/virelyx258/cn.seedsoft.realzhixue_AstroBox_Release
- 提交短哈希：`768fb4d`

---
此 PR 由 [AstroBooox Creator Console](https://astrobooox-ng.waijade.cn/) 生成，如有问题前往 [AstroBooox 仓库](https://github.com/CheongSzesuen/AstroBooox) 提交 [Issue](https://github.com/CheongSzesuen/AstroBooox/issues)。