### PR TITLE
[ABoooxCC] 发布 环间跳跳糖ProMax 快应用

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -213,3 +213,4 @@ com.uzens.calculator,矩阵计算器,quick_app,jes-benjamin,com.uzens.calculator
 979808574686,【第二套】EdgeUI-照片表盘2,watchface,Hobjl-lian,astrobox-resource-979808574686,486dcf7,media/icons.png,media/ab封面图.jpg,Hobjl;照片表盘,xiaomi,xmrw5;xmrw6;xmb10;xmb9;xmb9p;xmb10p,force_paid
 979880470803,「时影」- 相册表盘,watchface,shantuskat,astrobox-resource-979880470803,57a970e,media/画板 81.png,media/画板 77.png,相册;二次元;照片;原神;明日方舟;蔚蓝档案;崩坏星穹铁道,xiaomi,xmb10nfc;xmb10;xmb9p;xmb10p;xmrw6,force_paid
 979833881771,「终旅」- 终末地风格相册表盘,watchface,shantuskat,astrobox-resource-979833881771,4048aaa,media/画板 4.png,media/画板 3.png,相册;照片;终末地;明日方舟;二次元;免费,xiaomi,xmb10;xmb10nfc;xmb9p;xmb10p;xmrw6,
+com.JumpEgg.solan,环间跳跳糖ProMax,quick_app,Solan-486,Astrobox-Resource_Release_AstroBox_Release,06bda6e,logo.png,Preview@1x.png,跳蛋;玩具;神器;太爽了;强强,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmrw5;xmrw5xring;xmrw6;xmb10p,


### PR DESCRIPTION
## 资源信息

- 资源名称：环间跳跳糖ProMax
- 资源 ID：com.JumpEgg.solan
- 资源类型：快应用（quick_app）
- 提交版本：V2（V1 已不再支持）
- 付费类型：免费
- AstroBoxCreator 加密功能：关闭
- 标签：跳蛋 / 玩具 / 神器 / 太爽了 / 强强

## 支持设备

- Xiaomi Smart Band 9（device_id: xmb9）
- Xiaomi Smart Band 9 Pro（device_id: xmb9p）
- Xiaomi Smart Band 10（device_id: xmb10）
- Xiaomi Smart Band 10 NFC（device_id: xmb10nfc）
- REDMI Watch 5（device_id: xmrw5）
- REDMI Watch 5 eSIM（device_id: xmrw5xring）
- REDMI Watch 6（device_id: xmrw6）
- Xiaomi Smart Band 10 Pro（device_id: xmb10p）

## 仓库信息

- 资源仓库：https://github.com/Solan-486/Astrobox-Resource_Release_AstroBox_Release
- 提交短哈希：`06bda6e`

## 图片资源（Raw）

- Icon：`logo.png`  
https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/logo.png
- Cover：`Preview@1x.png`  
https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/Preview%401x.png
- Preview：
- `1 (1).png`
  https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/1%20(1).png
- `1 (2).png`
  https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/1%20(2).png
- `Vela_9Pro-2026-08-01-15-05-44.png`
  https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/Vela_9Pro-2026-08-01-15-05-44.png
- `Vela_Band10-2026-08-01-15-04-51.png`
  https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/Vela_Band10-2026-08-01-15-04-51.png

## 下载资源（downloads）

- Xiaomi Smart Band 9（device_id: xmb9）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
- Xiaomi Smart Band 9 Pro（device_id: xmb9p）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
- Xiaomi Smart Band 10（device_id: xmb10）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
- Xiaomi Smart Band 10 NFC（device_id: xmb10nfc）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
- REDMI Watch 5（device_id: xmrw5）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
- REDMI Watch 5 eSIM（device_id: xmrw5xring）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
- REDMI Watch 6（device_id: xmrw6）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
- Xiaomi Smart Band 10 Pro（device_id: xmb10p）
  - version: `1.0.1`
  - file: `环间跳跳糖ProMax.rpk`
  - raw: https://raw.githubusercontent.com/Solan-486/com.jumpegg.solan_AstroBox_Release/refs/heads/main/%E7%8E%AF%E9%97%B4%E8%B7%B3%E8%B7%B3%E7%B3%96ProMax.rpk
## 链接（manifest_v2.links）

- 手机端同步器下载（package）：https://pan.quark.cn/s/9a1c6ea3a142

---
此 PR 由 [AstroBooox Creator Console](https://astrobooox-ng.waijade.cn/) 生成，如有问题前往 [AstroBooox 仓库](https://github.com/CheongSzesuen/AstroBooox) 提交 [Issue](https://github.com/CheongSzesuen/AstroBooox/issues)。