### PR TITLE
[OBCC] Add 21点

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -228,3 +228,4 @@ com.uzens.calculator,矩阵计算器,quick_app,jes-benjamin,com.uzens.calculator
 979801672119,『凝』-罗小黑24节气2024,watchface,shantuskat,astrobox-resource-979801672119,f04b103,media/画板 1.png,media/画板 32.png,罗小黑;免费;poolux studio,xiaomi,xmb10;xmb10nfc;xmb10p;xmb9p;xmrw5;xmrw5xring;xmws5;xmrw6;xmb9,
 979820627644,【安装我】SnapUI-照片表盘,watchface,Hobjl-lian,astrobox-resource-979820627644,0f2a6c8,media/icons.png,media/Ab头图1.jpg,Hobjl;表盘,xiaomi,xmrw5;xmrw5xring;xmrw6;xmb10;xmb10nfc;xmb10p;xmb9;xmb9p,force_paid
 979808744500,邦！盘 DIY · 相册表盘,watchface,hrsthrt74,bang-diy-for-astrobox,fdb7ffa,media/iconB.png,media/coverB.png,hrsthrt74;邦邦;mygo;mujica;bang;diy;相册;相册表盘,xiaomi,xmrw5;xmrw5xring;xmrw6;xmb10p;xmb9p;xmws4xring;xmws441;xmws4;xmws5,force_paid
+com.stardew.calicojack,21点,quick_app,Rikka-45,astrobox-resource-com.stardew.calicojack,c36a567,media/icon.webp,media/cover.webp,星露谷物语;21点,Xiaomi,xmb10p;m67;xmb9p,


### PR DESCRIPTION
## 资源信息

- 资源名称：21点
- 资源 ID：com.stardew.calicojack
- 资源类型：快应用（quick_app）
- 提交清单：manifest_v2
- 付费类型：免费
- 标签：星露谷物语 / 21点

## 支持设备

- Xiaomi Smart Band 10 Pro（device_id: xmb10p）
- Xiaomi Smart Band 8 Pro（device_id: m67）
- Xiaomi Smart Band 9 Pro（device_id: xmb9p）

## 仓库信息

- 资源仓库：https://github.com/Rikka-45/astrobox-resource-com.stardew.calicojack
- 提交短哈希：c36a567

## 图片资源

- Icon：media/icon.webp
  https://raw.githubusercontent.com/Rikka-45/astrobox-resource-com.stardew.calicojack/refs/heads/main/media/icon.webp
- Cover：media/cover.webp
  https://raw.githubusercontent.com/Rikka-45/astrobox-resource-com.stardew.calicojack/refs/heads/main/media/cover.webp
- Preview：
  - media/preview-2.webp
    https://raw.githubusercontent.com/Rikka-45/astrobox-resource-com.stardew.calicojack/refs/heads/main/media/preview-2.webp

## 下载资源（downloads）

- downloads/0-_CalicoJack-v2.0-settings.rpk
  - version: 1.0
  - devices: Xiaomi Smart Band 10 Pro（xmb10p）
  - raw: https://raw.githubusercontent.com/Rikka-45/astrobox-resource-com.stardew.calicojack/refs/heads/main/downloads/0-_CalicoJack-v2.0-settings.rpk
  - sha256: 956fcf770870ef48f5a64de05539085088500129c53cda9af4ca1603f041b382
- downloads/1-_CalicoJack-v2.0-settings.rpk
  - version: 1.0
  - devices: Xiaomi Smart Band 8 Pro（m67）
  - raw: https://raw.githubusercontent.com/Rikka-45/astrobox-resource-com.stardew.calicojack/refs/heads/main/downloads/1-_CalicoJack-v2.0-settings.rpk
  - sha256: 956fcf770870ef48f5a64de05539085088500129c53cda9af4ca1603f041b382
- downloads/2-_CalicoJack-v2.0-settings.rpk
  - version: 1.0
  - devices: Xiaomi Smart Band 9 Pro（xmb9p）
  - raw: https://raw.githubusercontent.com/Rikka-45/astrobox-resource-com.stardew.calicojack/refs/heads/main/downloads/2-_CalicoJack-v2.0-settings.rpk
  - sha256: 956fcf770870ef48f5a64de05539085088500129c53cda9af4ca1603f041b382

---

此 PR 由 [OronBox 创作者中心](https://oronbox.zxor.org) 提交。Submitted through OronBox Creator Center.
