### PR TITLE
[ABCC] Add new resource: 商业大亨

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -230,3 +230,4 @@ com.matrixfive.airpistol,轻音效,quick_app,jinmohan,QingYinXiao-AstroBox,2e179
 com.schedule.vela,腕上课程表,quick_app,Jursin,astrobox-resource-com-schedule-vela,94ead66,media/logo.png,media/banner.png,课程表,xiaomi,xmb9,
 com.azuma.dic,英汉词典-五万词库中英互译,quick_app,AzumaChiaki,AzumaDic,bce9425,media/logo.png,media/780DC36BE6420AF666B84B57D794E620.png,词典;学习;工具;英语,xiaomi,xmrw5;xmrw5xring;xmrw6;xmb10nfc;xmb10;xmb10p;xmb9;xmb9p,force_paid
 moe.mcns.WearPost,腕上信驿,quick_app,FelixFan-CN,moe.mcns.wearpost_AstroBox_Release,20da525,logo (1).png.png,封面.png,邮件;独立,xiaomi,xmws3;xmws4;xmws4xring;xmrw5xring;xmrw5;xmws441;xmrw6;xmws5;xmb9p;xmb10p,force_paid
+com.personal.astrobox.businessempire,商业大亨,quick_app,liburce0412-alt,astrobox-resource-com-personal-astrobox-businessempire,1de7e1d,media/icon.png,media/business-home.png,游戏 / 模拟经营,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmb10p,force_paid

--- a/index_v2.csv
+++ b/index_v2.csv
@@ -230,4 +230,4 @@ com.matrixfive.airpistol,轻音效,quick_app,jinmohan,QingYinXiao-AstroBox,2e179
 com.schedule.vela,腕上课程表,quick_app,Jursin,astrobox-resource-com-schedule-vela,94ead66,media/logo.png,media/banner.png,课程表,xiaomi,xmb9,
 com.azuma.dic,英汉词典-五万词库中英互译,quick_app,AzumaChiaki,AzumaDic,bce9425,media/logo.png,media/780DC36BE6420AF666B84B57D794E620.png,词典;学习;工具;英语,xiaomi,xmrw5;xmrw5xring;xmrw6;xmb10nfc;xmb10;xmb10p;xmb9;xmb9p,force_paid
 moe.mcns.WearPost,腕上信驿,quick_app,FelixFan-CN,moe.mcns.wearpost_AstroBox_Release,20da525,logo (1).png.png,封面.png,邮件;独立,xiaomi,xmws3;xmws4;xmws4xring;xmrw5xring;xmrw5;xmws441;xmrw6;xmws5;xmb9p;xmb10p,force_paid
-com.personal.astrobox.businessempire,商业大亨,quick_app,liburce0412-alt,astrobox-resource-com-personal-astrobox-businessempire,1de7e1d,media/icon.png,media/business-home.png,游戏 / 模拟经营,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmb10p,force_paid
+com.personal.astrobox.businessempire,商业大亨,quick_app,liburce0412-alt,astrobox-resource-com-personal-astrobox-businessempire,bc331f0,media/icon.png,media/cover-1200x800.png,游戏 / 模拟经营,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmb10p,force_paid


### PR DESCRIPTION
发布商业大亨 v1.0.3，支持小米手环9、9 Pro、10、10 Pro，已配置爱发电强制付费、四设备资源映射及加密下载。