### PR TITLE
[ABoooxCC] 发布 Apple地球 表盘

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -242,3 +242,4 @@ io.github.mcxcc303.dsband.band,DSBand,quick_app,MCXCC303,astrobox-resource-io-gi
 979851021027,Rainbow（支持相册编辑）,watchface,zzz78bc,astrobox-resource-979851021027,f8e61f2,media/分组 1.png,media/画板 3.webp,表盘,xiaomi,xmrw5;xmrw5xring;xmrw6;xmb10p;xmb10;xmb10nfc;xmb9p,
 canopus_bluetoothaudio,Canopus 蓝牙音频扩展模块,canopus,Searchstars,astrobox-resource-canopus_bluetoothaudio,76cf568,media/Frame 6-2 1.png,media/Frame 11.png,Canopus;蓝牙;蓝牙耳机;耳机;音乐;播放器;模块;扩展;内核扩展,xiaomi,xmb10p,force_paid
 com.HNTPVZchv.watch.demo,植物大战僵尸,quick_app,HazeNoTea,Plants_VS_Zombie_Vela_Chv,0a194f4,media/logo-256.png,media/2：3-低分辨率.png,游戏;塔防,xiaomi,xmb10p;xmb10,
+979838458237,Apple地球,watchface,zsmlm,979838458237_AstroBox_Release,f7d71a3,Snipaste_2026-08-19_21-31-55.png,Snipaste_2026-08-19_23-02-55.png,表盘,xiaomi,xmb9p;xmb10p,


### PR DESCRIPTION
## 资源信息

- 资源名称：Apple地球
- 资源 ID：979838458237
- 资源类型：表盘（watch_face）
- 提交版本：V2（V1 已不再支持）
- 付费类型：免费
- AstroBoxCreator 加密功能：关闭
- 标签：表盘

## 支持设备

- Xiaomi Smart Band 9 Pro（device_id: xmb9p）
- Xiaomi Smart Band 10 Pro（device_id: xmb10p）

## 仓库信息

- 资源仓库：https://github.com/zsmlm/979838458237_AstroBox_Release
- 提交短哈希：`f7d71a3`

## 图片资源（Raw）

- Icon：`Snipaste_2026-08-19_21-31-55.png`  
https://raw.githubusercontent.com/zsmlm/979838458237_AstroBox_Release/refs/heads/main/Snipaste_2026-08-19_21-31-55.png
- Cover：`Snipaste_2026-08-19_23-02-55.png`  
https://raw.githubusercontent.com/zsmlm/979838458237_AstroBox_Release/refs/heads/main/Snipaste_2026-08-19_23-02-55.png
- Preview：
- `f7735de78567e140fd447fd1f42097be.png`
  https://raw.githubusercontent.com/zsmlm/979838458237_AstroBox_Release/refs/heads/main/f7735de78567e140fd447fd1f42097be.png

## 下载资源（downloads）

- Xiaomi Smart Band 9 Pro（device_id: xmb9p）
  - version: `1.0.0`
  - file: `Apple 地球-V7-202607011341.bin`
  - raw: https://raw.githubusercontent.com/zsmlm/979838458237_AstroBox_Release/refs/heads/main/Apple%20%E5%9C%B0%E7%90%83-V7-202607011341.bin
- Xiaomi Smart Band 10 Pro（device_id: xmb10p）
  - version: `1.0.0`
  - file: `Apple 地球-V7-202607011341.bin`
  - raw: https://raw.githubusercontent.com/zsmlm/979838458237_AstroBox_Release/refs/heads/main/Apple%20%E5%9C%B0%E7%90%83-V7-202607011341.bin
## 链接（manifest_v2.links）

- 为空

---
此 PR 由 [AstroBooox Creator Console](https://astrobooox-ng.waijade.cn/) 生成，如有问题前往 [AstroBooox 仓库](https://github.com/CheongSzesuen/AstroBooox) 提交 [Issue](https://github.com/CheongSzesuen/AstroBooox/issues)。