### PR TITLE
[ABCC] Add new resource: 喵伴

### DIFF
--- a/index_v2.csv
+++ b/index_v2.csv
@@ -259,3 +259,4 @@ com.local.brainfucklearner,Brainfuck编辑器,quick_app,Rubbishzzz,astrobox-reso
 979843426542,亮点＋,watchface,SL9325,979843426107_AstroBox_Release,7ba2c8b,media/46444.png,media/44887.jpg,SL9325;SLWF;蓝色系;多样式;显秒;表盘,xiaomi,xmb10p,
 cn.sabbatofthewitch.qihe,魔女的夜宴,quick_app,qihe114514,astrobox-resource-cn-sabbatofthewitch-qihe,83715f2,media/icon_optimized.png,media/封面720.png,游戏;glagame,xiaomi,xmb10nfc;xmb10p;xmb10;xmb9p;xmrw5;xmrw5xring;xmrw6;xmb9;xmws3;xmws4xring;xmws441;xmws4;xmws5,force_paid
 com.matrixfive.airpistol,轻音效,quick_app,jinmohan,QingYinXiao-AstroBox,49687ad,media/logo.png,media/q1-z.png,创意软件;音效,xiaomi,xmrw5;xmrw5xring;xmrw6;xmws3;xmws4xring;xmws441;xmws4;xmws5,force_paid
+com.awu.watch.petpal,喵伴,quick_app,jianding24,miaoban-astrobox-release,935672a,media/icon.png,media/cover.png,喵伴;小猫;宠物;养成;治愈;装饰;小游戏;表盘联动;付费,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmb10p;xmrw5;xmrw5xring;xmrw6,paid


### PR DESCRIPTION
提交喵伴 2.0.0。

付费快应用资源，支持小米手环 9/10、9 Pro/10 Pro 和 Redmi Watch 5/6。
本版包含小猫养成、小窝装饰、小游戏和喵伴表盘联动。