### PR TITLE
[ABCC] Add new resource: 喵伴

### DIFF
--- a/tmp/jianding24/miaoban-astrobox-release/request.json
+++ b/tmp/jianding24/miaoban-astrobox-release/request.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "mode": "create",
+  "original_id": null,
+  "base_entry_digest": null,
+  "base_catalog_commit": "ac68a4590edca7458dedef0bf7c44ba7258efc4c"
+}

--- a/tmp/jianding24/miaoban-astrobox-release/resource.csv
+++ b/tmp/jianding24/miaoban-astrobox-release/resource.csv
@@ -1,2 +1,2 @@
 id,name,restype,repo_owner,repo_name,repo_commit_hash,icon,cover,tags,device_vendors,devices,paid_type
-com.awu.watch.petpal,喵伴,quick_app,jianding24,miaoban-astrobox-release,935672a,media/icon.png,media/cover.png,喵伴;小猫;宠物;养成;治愈;装饰;小游戏;表盘联动;付费,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmb10p;xmrw5;xmrw5xring;xmrw6,paid
+com.awu.watch.petpal,喵伴,quick_app,jianding24,miaoban-astrobox-release,c45419e,media/icon.png,media/cover.jpg,喵伴;小猫;宠物;养成;治愈;装饰;小游戏;表盘联动;付费,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmb10p;xmrw5;xmrw5xring;xmrw6,paid

--- a/tmp/jianding24/miaoban-astrobox-release/resource.csv
+++ b/tmp/jianding24/miaoban-astrobox-release/resource.csv
@@ -1,0 +1,2 @@
+id,name,restype,repo_owner,repo_name,repo_commit_hash,icon,cover,tags,device_vendors,devices,paid_type
+com.awu.watch.petpal,喵伴,quick_app,jianding24,miaoban-astrobox-release,935672a,media/icon.png,media/cover.png,喵伴;小猫;宠物;养成;治愈;装饰;小游戏;表盘联动;付费,xiaomi,xmb9;xmb9p;xmb10;xmb10nfc;xmb10p;xmrw5;xmrw5xring;xmrw6,paid


### PR DESCRIPTION
提交喵伴 2.0.0。

付费快应用资源，支持小米手环 9/10、9 Pro/10 Pro 和 Redmi Watch 5/6。
本版包含小猫养成、小窝装饰、小游戏和喵伴表盘联动。